### PR TITLE
changed to const char*

### DIFF
--- a/json-arrays-in-object/main/main.c
+++ b/json-arrays-in-object/main/main.c
@@ -28,7 +28,7 @@ cJSON *Create_array_of_anything(cJSON **objects,int array_num)
 	return root;
 }
 
-char *JSON_Types(int type) {
+const char *JSON_Types(int type) {
 	if (type == cJSON_Invalid) return ("cJSON_Invalid");
 	if (type == cJSON_False) return ("cJSON_False");
 	if (type == cJSON_True) return ("cJSON_True");


### PR DESCRIPTION
To eliminate these warnings
src/main.cpp:66:52: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  if (type == cJSON_Invalid) return ("cJSON_Invalid");
                                                    ^
src/main.cpp:67:48: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  if (type == cJSON_False) return ("cJSON_False");
                                                ^
src/main.cpp:68:46: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  if (type == cJSON_True) return ("cJSON_True");
                                              ^
src/main.cpp:69:46: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  if (type == cJSON_NULL) return ("cJSON_NULL");
                                              ^
src/main.cpp:70:50: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  if (type == cJSON_Number) return ("cJSON_Number");
                                                  ^
src/main.cpp:71:50: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  if (type == cJSON_String) return ("cJSON_String");
                                                  ^
src/main.cpp:72:48: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  if (type == cJSON_Array) return ("cJSON_Array");
                                                ^
src/main.cpp:73:50: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  if (type == cJSON_Object) return ("cJSON_Object");
                                                  ^
src/main.cpp:74:44: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  if (type == cJSON_Raw) return ("cJSON_Raw");